### PR TITLE
Atualiza expressão 'aberrante'

### DIFF
--- a/projects/boston_housing/boston_housing_PT.ipynb
+++ b/projects/boston_housing/boston_housing_PT.ipynb
@@ -50,7 +50,7 @@
     "\n",
     "O conjunto de dados para este projeto se origina do [repositório de Machine Learning da UCI](https://archive.ics.uci.edu/ml/datasets/Housing). Os dados de imóveis de Boston foram coletados em 1978 e cada uma das 489 entradas representa dados agregados sobre 14 atributos para imóveis de vários subúrbios de Boston. Para o propósito deste projeto, os passos de pré-processamento a seguir foram feitos para esse conjunto de dados:\n",
     "- 16 observações de dados possuem um valor `'MEDV'` de 50.0. Essas observações provavelmente contêm **valores ausentes ou censurados** e foram removidas.\n",
-    "- 1 observação de dados tem um valor `'RM'` de 8.78. Essa observação pode ser considerada **aberrante** e foi removida.\n",
+    "- 1 observação de dados tem um valor `'RM'` de 8.78. Essa observação pode ser considerada **valor atípico (outlier)** e foi removida.\n",
     "- Os atributos `'RM'`, `'LSTAT'`, `'PTRATIO'`, and `'MEDV'` são essenciais. O resto dos **atributos irrelevantes** foram excluídos.\n",
     "- O atributo `'MEDV'` foi **escalonado multiplicativamente** para considerar 35 anos de inflação de mercado.\n",
     "\n",


### PR DESCRIPTION
Não sei se isso já foi discutido antes, mas creio que não sera necessário traduzir *outlier* ou caso seja feito, utilizar a expressão 'valor atípico' que parece mais apropriado. Esta expressão estará mais frequente no P3. 

Referências:
- https://pt.wikipedia.org/wiki/Outlier
Utiliza outlier, valor aberrante ou valor atípico

- http://glossario.spestatistica.pt/
Utiliza estas expressões: valores atípicos/discordantes/aberrantes/discrepantes; valores anómalos [PT]/anômalos [BR]; outliers
*outliers* parece ser válido tanto para PT quanto para BR. 

- Resultados do Google
    - Outlier: 10M
    - Valor Atípico: 700k
    - Valor aberrante: 400k