### PR TITLE
Atualiza o primeiro requerimento da Q4

### DIFF
--- a/projects/boston_housing/boston_housing_PT.ipynb
+++ b/projects/boston_housing/boston_housing_PT.ipynb
@@ -344,7 +344,7 @@
    "metadata": {},
    "source": [
     "### Questão 4 - Compreendendo os Dados\n",
-    "* Escolha um dos gráficos acima e determine a profundidade máxima para o modelo.\n",
+    "* Escolha qualquer um dos gráficos acima e mencione a profundidade máxima escolhida.\n",
     "* O que acontece com a pontuação da curva de treinamento se mais pontos de treinamento são adicionados? E o que acontece com a curva de teste?\n",
     "* Ter mais pontos de treinamento beneficia o modelo?\n",
     "\n",


### PR DESCRIPTION
Esta é uma confusão recorrente entre os alunos. O projeto em inglês também está ambíguo esta interpretação. Na realidade não é necessário **determinar** a profundidade máxima para o modelo. A intenção desta questão é que o aluno escolha qualquer um dos quatro gráficos para discussão. Geralmente as repostas dos alunos começam com algo do tipo 'a melhor profundidade máxima para o modelo é max_depth = 3' o que não era a intenção.