### PR TITLE
Atualiza a Questão 5 para três questões

### DIFF
--- a/projects/boston_housing/boston_housing_PT.ipynb
+++ b/projects/boston_housing/boston_housing_PT.ipynb
@@ -385,7 +385,8 @@
    "source": [
     "### Questão 5 - Equilíbrio entre viés e variância\n",
     "* Quando o modelo é treinado com o profundidade máxima 1, será que o modelo sofre mais de viés (erro sistemático) ou variância (erro aleatório)?\n",
-    "* E o que acontece quando o modelo é treinado com profundidade máxima 10? Quais pistas visuais existem no gráfico para justificar suas conclusões?\n",
+    "* E o que acontece quando o modelo é treinado com profundidade máxima 10?\n",
+    "* Quais pistas visuais existem no gráfico para justificar suas conclusões?\n",
     "\n",
     "**Dica:** Como você sabe que um modelo está experimentando viés alto ou variância alta? Viés alto é um sinal de *underfitting* (o modelo não é complexo o suficiente para aprender os dados) e alta variância é um sinal de *overfitting* (o modelo está \"decorando\" os dados e não consegue generalizar bem o problema). Pense em modelos (com profundidade de 1 e 10, por exemplo) e qual deles está alinhado com qual parte do equilíbrio."
    ]


### PR DESCRIPTION
A questão 5 possui três questões à serem respondidas. No entanto, as duas últimas estão dentro do mesmo marcador. Muitos alunos estão achando que só precisam responder duas questões (ou justificam visualmente apenas para profundidade máxima = 10).